### PR TITLE
add helm support to the sample

### DIFF
--- a/deployment/certificate/Dockerfile
+++ b/deployment/certificate/Dockerfile
@@ -1,3 +1,13 @@
 
 FROM ubuntu:18.04
 RUN apt-get update && apt-get install -y openssh-server
+
+####
+ARG  UID
+ARG  GID
+## must use ; here to ignore user exist status code
+RUN  [ ${GID} -gt 0 ] && groupadd -f -g ${GID} docker; \
+     [ ${UID} -gt 0 ] && useradd -d /home/docker -g ${GID} -K UID_MAX=${UID} -K UID_MIN=${UID} docker; \
+     echo
+USER ${UID}
+####

--- a/deployment/kubernetes/helm/.gitignore
+++ b/deployment/kubernetes/helm/.gitignore
@@ -1,0 +1,2 @@
+cdn-transcode/values.yaml
+*-pv.yaml

--- a/deployment/kubernetes/helm/CMakeLists.txt
+++ b/deployment/kubernetes/helm/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(service "kubernetes")
+set(service "helm")
 include("${CMAKE_SOURCE_DIR}/script/service.cmake")
 include("${CMAKE_SOURCE_DIR}/script/deployment.cmake")
-include("${CMAKE_SOURCE_DIR}/script/scan-all.cmake")
+add_custom_target(volume ${CMAKE_CURRENT_SOURCE_DIR}/mkvolume.sh)

--- a/deployment/kubernetes/helm/build.sh
+++ b/deployment/kubernetes/helm/build.sh
@@ -5,6 +5,10 @@ NVODS="${1:-1}"
 NLIVES="${2:-1}"
 HOSTIP=$(ip route get 8.8.8.8 | awk '/ src /{split(substr($0,index($0," src ")),f);print f[2];exit}')
 
+if [ ! -x /usr/bin/helm ] && [ ! -x /usr/local/bin/helm ]; then
+    exit 0
+fi 
+
 echo "Generating persistent volume yaml(s)"
 # list all workers
 hosts=($(kubectl get node -l vcac-zone!=yes -o custom-columns=NAME:metadata.name,STATUS:status.conditions[-1].type,TAINT:spec.taints | grep " Ready " | grep -v "NoSchedule" | cut -f1 -d' '))

--- a/deployment/kubernetes/helm/build.sh
+++ b/deployment/kubernetes/helm/build.sh
@@ -1,0 +1,28 @@
+#!/bin/bash -e
+
+DIR=$(dirname $(readlink -f "$0"))
+NVODS="${1:-1}"
+NLIVES="${2:-1}"
+HOSTIP=$(ip route get 8.8.8.8 | awk '/ src /{split(substr($0,index($0," src ")),f);print f[2];exit}')
+
+echo "Generating persistent volume yaml(s)"
+# list all workers
+hosts=($(kubectl get node -l vcac-zone!=yes -o custom-columns=NAME:metadata.name,STATUS:status.conditions[-1].type,TAINT:spec.taints | grep " Ready " | grep -v "NoSchedule" | cut -f1 -d' '))
+if test ${#hosts[@]} -eq 0; then
+    printf "\nFailed to locate worker node(s) for shared storage\n\n"
+    exit 1
+elif test ${#hosts[@]} -lt 2; then
+    hosts=(${hosts[0]} ${hosts[0]})
+fi
+
+export HTML_VOLUME_PATH=/tmp/volume/html
+export HTML_VOLUME_SIZE=1Gi
+export HTML_VOLUME_HOST=${hosts[0]}
+
+for pv in "$DIR"/*-pv.yaml.m4; do
+    m4 $(env | grep _VOLUME_ | sed 's/^/-D/') "$pv" > "${pv/.m4/}"
+done
+
+echo "Generating helm chart"
+m4 -DNVODS=${NVODS} -DNLIVES=${NLIVES} -DUSERID=$(id -u) -DGROUPID=$(id -g) -DHOSTIP=${HOSTIP} $(env | grep _VOLUME_ | sed 's/^/-D/') -I "${DIR}/cdn-transcode" "$DIR/cdn-transcode/values.yaml.m4" > "$DIR/cdn-transcode/values.yaml"
+

--- a/deployment/kubernetes/helm/build.sh
+++ b/deployment/kubernetes/helm/build.sh
@@ -19,6 +19,18 @@ export HTML_VOLUME_PATH=/tmp/volume/html
 export HTML_VOLUME_SIZE=1Gi
 export HTML_VOLUME_HOST=${hosts[0]}
 
+export ARCHIVE_VOLUME_PATH=/tmp/volume/video/archive
+export ARCHIVE_VOLUME_SIZE=1Gi
+export ARCHIVE_VOLUME_HOST=${hosts[0]}
+
+export DASH_VOLUME_PATH=/tmp/volume/video/dash
+export DASH_VOLUME_SIZE=1Gi
+export DASH_VOLUME_HOST=${hosts[1]}
+
+export HLS_VOLUME_PATH=/tmp/volume/video/hls
+export HLS_VOLUME_SIZE=1Gi
+export HLS_VOLUME_HOST=${hosts[1]}
+
 for pv in "$DIR"/*-pv.yaml.m4; do
     m4 $(env | grep _VOLUME_ | sed 's/^/-D/') "$pv" > "${pv/.m4/}"
 done

--- a/deployment/kubernetes/helm/cdn-transcode/Chart.yaml
+++ b/deployment/kubernetes/helm/cdn-transcode/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+appVersion: 0.1.0
+description: A Helm chart for the CDN Transcode sample
+home: https://github.com/OpenVisualCloud/CDN-Transocde-Sample
+icon: https://raw.githubusercontent.com/OpenVisualCloud/CDN-Transcode-Sample/master/volume/html/favicon.ico
+name: cdn-transcode-sample
+sources:
+- https://github.com/OpenVisualCloud/CDN-Transcode-Sample
+type: application
+version: 0.1.0

--- a/deployment/kubernetes/helm/cdn-transcode/README.md
+++ b/deployment/kubernetes/helm/cdn-transcode/README.md
@@ -1,0 +1,33 @@
+
+The CDN Transcode Sample is an Open Visual Cloud software stack with all required open source ingredients well integrated to provide out-of-box CDN media transcode service, including live streaming and video on demand. It also provides docker-based media delivery software development environment upon which developer can easily build their specific applications.  
+
+### Prerequisites:
+
+The Sample assumes that you have a ready-to-use Kubernetes cluster environment with `helm` to manage the applicatoin deployment.  
+
+### Build:
+
+```bash
+mkdir build
+cd build
+cmake ..
+make
+```
+
+### Create Shared Volumes:
+
+```bash
+make volume
+```
+
+The `make volume` command creates local persistent volumes under the /tmp directory of the first two Kubernetes workers. This is a temporary solution for quick sample deployment. For scalability beyond a two-node cluster, consider rewriting the `mkvolume.sh` script.
+
+`make volume` uses `scp` to copy volumes to the Kubernetes workers, assuming that the Kubernetes master can password-less access to the Kubernetes workers.  
+
+### Start/Stop Sample:
+
+```bash
+make start_helm
+make stop_helm
+```
+

--- a/deployment/kubernetes/helm/cdn-transcode/templates/cdn-service-deployment.yaml
+++ b/deployment/kubernetes/helm/cdn-transcode/templates/cdn-service-deployment.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: cdn-service
+  name: cdn-service
+spec:
+  selector:
+    matchLabels:
+      app: cdn-service
+  replicas: 1
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: cdn-service
+    spec:
+      containers:
+      - args:
+        - bash
+        - -c
+        - /home/main.py&/usr/local/sbin/nginx
+        image: ovc_cdn_service:latest
+        imagePullPolicy: IfNotPresent
+        name: cdn-service
+        ports:
+        - containerPort: 8080
+        - containerPort: 1935
+        volumeMounts:
+          - mountPath: /var/run/secrets
+            name: secrets
+            readOnly: true
+          - mountPath: /var/www/html
+            name: html
+            readOnly: true
+      volumes:
+        - name: secrets
+          secret:
+            secretName: self-signed-certificate
+        - name: html
+          persistentVolumeClaim:
+            claimName: html
+      restartPolicy: Always

--- a/deployment/kubernetes/helm/cdn-transcode/templates/cdn-service-deployment.yaml
+++ b/deployment/kubernetes/helm/cdn-transcode/templates/cdn-service-deployment.yaml
@@ -33,6 +33,13 @@ spec:
           - mountPath: /var/www/html
             name: html
             readOnly: true
+          - mountPath: /var/www/archive
+            name: archive
+            readOnly: true
+          - mountPath: /var/www/dash
+            name: dash
+          - mountPath: /var/www/hls
+            name: hls
       volumes:
         - name: secrets
           secret:
@@ -40,4 +47,13 @@ spec:
         - name: html
           persistentVolumeClaim:
             claimName: html
+        - name: archive
+          persistentVolumeClaim:
+            claimName: video-archive
+        - name: dash
+          persistentVolumeClaim:
+            claimName: video-dash
+        - name: hls
+          persistentVolumeClaim:
+            claimName: video-hls
       restartPolicy: Always

--- a/deployment/kubernetes/helm/cdn-transcode/templates/cdn-service-service.yaml
+++ b/deployment/kubernetes/helm/cdn-transcode/templates/cdn-service-service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: cdn-service
+  name: cdn-service
+spec:
+  ports:
+  - name: "443"
+    port: 443
+    targetPort: 8080
+  - name: "1935"
+    port: 1935
+    targetPort: 1935
+  externalIPs:
+    - "{{ .Values.cdn.hostIP }}"
+  selector:
+    app: cdn-service

--- a/deployment/kubernetes/helm/cdn-transcode/templates/html-pvc.yaml
+++ b/deployment/kubernetes/helm/cdn-transcode/templates/html-pvc.yaml
@@ -1,0 +1,13 @@
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: html
+spec:
+  accessModes:
+    - ReadOnlyMany
+  storageClassName: html
+  resources:
+    requests:
+      storage: "{{ .Values.volume.html.size }}"
+

--- a/deployment/kubernetes/helm/cdn-transcode/templates/kafka-service-deployment.yaml
+++ b/deployment/kubernetes/helm/cdn-transcode/templates/kafka-service-deployment.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: kafka-service
+  name: kafka-service
+spec:
+  selector:
+    matchLabels:
+      app: kafka-service
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: kafka-service
+    spec:
+      containers:
+      - env:
+        - name: KAFKA_ADVERTISED_HOST_NAME
+          value: kafka-service
+        - name: KAFKA_ADVERTISED_LISTENERS
+          value: PLAINTEXT://kafka-service:9092
+        - name: KAFKA_ADVERTISED_PORT
+          value: "9092"
+        - name: KAFKA_AUTO_CREATE_TOPICS_ENABLE
+          value: "true"
+        - name: KAFKA_BROKER_ID
+          value: "1"
+        - name: KAFKA_CREATE_TOPICS
+          value: content_provider_sched:16:1
+        - name: KAFKA_DEFAULT_REPLICATION_FACTOR
+          value: "1"
+        - name: KAFKA_HEAP_OPTS
+          value: -Xmx{{ .Values.kafka.heapSize }} -Xms{{ .Values.kafka.heapSize }}
+        - name: KAFKA_INTER_BROKER_LISTENER_NAME
+          value: PLAINTEXT
+        - name: KAFKA_LISTENER_SECURITY_PROTOCOL_MAP
+          value: PLAINTEXT:PLAINTEXT
+        - name: KAFKA_LOG4J_LOGGERS
+          value: kafka=ERROR,kafka.controller=ERROR,state.change.logger=ERROR,org.apache.kafka=ERROR
+        - name: KAFKA_LOG4J_ROOT_LOGLEVEL
+          value: ERROR
+        - name: KAFKA_LOG_RETENTION_HOURS
+          value: "8"
+        - name: KAFKA_NUM_PARTITIONS
+          value: "16"
+        - name: KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR
+          value: "1"
+        - name: KAFKA_ZOOKEEPER_CONNECT
+          value: zookeeper-service:2181
+        image: wurstmeister/kafka:latest
+        name: kafka-service
+        ports:
+        - containerPort: 9092
+      restartPolicy: Always

--- a/deployment/kubernetes/helm/cdn-transcode/templates/kafka-service-service.yaml
+++ b/deployment/kubernetes/helm/cdn-transcode/templates/kafka-service-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: kafka-service
+  name: kafka-service
+spec:
+  ports:
+  - name: "9092"
+    port: 9092
+    targetPort: 9092
+  selector:
+    app: kafka-service

--- a/deployment/kubernetes/helm/cdn-transcode/templates/live-service-deployment.yaml
+++ b/deployment/kubernetes/helm/cdn-transcode/templates/live-service-deployment.yaml
@@ -1,25 +1,52 @@
+
+{{- range $i,$v1 := .Values.liveTranscode.streams }}
+{{- if lt (int $i) (int $.Values.liveTranscode.replicas) }}
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: live-service
-  name: live-service
+    app: live-service-{{ $i }}
+  name: live-service-{{ $i }}
 spec:
   selector:
     matchLabels:
-      app: live-service
-  replicas: {{ .Values.liveTranscode.replicas }}
+      app: live-service-{{ $i }}
+  replicas: 1
   template:
     metadata:
       creationTimestamp: null
       labels:
-        app: live-service
+        app: live-service-{{ $i }}
     spec:
       containers:
       - image: ovc_software_transcode_service:latest
-        command: ["/bin/bash","-c","ffmpeg -re -stream_loop -1 -i /var/www/archive/bbb_sunflower_1080p_30fps_normal.mp4 -vf scale=2560:1440 -c:v libsvt_hevc -b:v 15M -forced-idr 1 -f flv rtmp://cdn-service/hls/big_buck_bunny_2560x1440 -vf scale=1920:1080 -c:v libsvt_hevc -b:v 10M -forced-idr 1 -f flv rtmp://cdn-service/hls/big_buck_bunny_1920x1080 -vf scale=1280:720 -c:v libx264 -b:v 8M -f flv rtmp://cdn-service/hls/big_buck_bunny_1280x720 -vf scale=854:480 -c:v libx264 -b:v 6M -f flv rtmp://cdn-service/hls/big_buck_bunny_854x480 -abr_pipeline"]
         imagePullPolicy: IfNotPresent
-        name: live-service
+        command: ["/usr/local/bin/ffmpeg","-re","-stream_loop","-1",
+            "-i","{{ .name }}",
+{{- range $k,$v2 := .transcode }}
+            "-vf","scale={{ .scale }}",
+            "-c:v","{{ .encoderType }}",
+            "-b:v","{{ .bitrate }}",
+            "-r","{{ .framerate }}",
+            "-g","{{ .gop }}",
+            "-bf","{{ .maxbframes }}",
+            "-refs","{{ .refsNum }}",
+            "-preset","{{ .preset }}",
+            "-forced-idr","1",
+{{- if eq ( hasPrefix "libsvt" .encoderType ) true }}
+            "-thread_count","96",
+{{- end }}
+            "-an",
+            "-f","flv","rtmp://cdn-service/{{ .protocol }}/media_{{ $i }}_{{ $k }}",
+{{- end }}
+            "-abr_pipeline"]
+        name: live-service-{{ $i }}
+        env:
+          - name: NO_PROXY
+            value: "cdn-service"
+          - name: no_proxy
+            value: "cdn-service"
         volumeMounts:
           - mountPath: /var/www/archive
             name: archive
@@ -29,3 +56,7 @@ spec:
           persistentVolumeClaim:
             claimName: video-archive
       restartPolicy: Always
+
+---
+{{- end }}
+{{- end }}

--- a/deployment/kubernetes/helm/cdn-transcode/templates/live-service-deployment.yaml
+++ b/deployment/kubernetes/helm/cdn-transcode/templates/live-service-deployment.yaml
@@ -17,6 +17,15 @@ spec:
     spec:
       containers:
       - image: ovc_software_transcode_service:latest
+        command: ["/bin/bash","-c","ffmpeg -re -stream_loop -1 -i /var/www/archive/bbb_sunflower_1080p_30fps_normal.mp4 -vf scale=2560:1440 -c:v libsvt_hevc -b:v 15M -forced-idr 1 -f flv rtmp://cdn-service/hls/big_buck_bunny_2560x1440 -vf scale=1920:1080 -c:v libsvt_hevc -b:v 10M -forced-idr 1 -f flv rtmp://cdn-service/hls/big_buck_bunny_1920x1080 -vf scale=1280:720 -c:v libx264 -b:v 8M -f flv rtmp://cdn-service/hls/big_buck_bunny_1280x720 -vf scale=854:480 -c:v libx264 -b:v 6M -f flv rtmp://cdn-service/hls/big_buck_bunny_854x480 -abr_pipeline"]
         imagePullPolicy: IfNotPresent
         name: live-service
+        volumeMounts:
+          - mountPath: /var/www/archive
+            name: archive
+            readOnly: true
+      volumes:
+        - name: archive
+          persistentVolumeClaim:
+            claimName: video-archive
       restartPolicy: Always

--- a/deployment/kubernetes/helm/cdn-transcode/templates/live-service-deployment.yaml
+++ b/deployment/kubernetes/helm/cdn-transcode/templates/live-service-deployment.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: live-service
+  name: live-service
+spec:
+  selector:
+    matchLabels:
+      app: live-service
+  replicas: {{ .Values.liveTranscode.replicas }}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: live-service
+    spec:
+      containers:
+      - image: ovc_software_transcode_service:latest
+        imagePullPolicy: IfNotPresent
+        name: live-service
+      restartPolicy: Always

--- a/deployment/kubernetes/helm/cdn-transcode/templates/redis-service-deployment.yaml
+++ b/deployment/kubernetes/helm/cdn-transcode/templates/redis-service-deployment.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: redis-service
+  name: redis-service
+spec:
+  selector:
+    matchLabels:
+      app: redis-service
+  replicas: 1
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: redis-service
+    spec:
+      containers:
+      - args:
+        - redis-server
+        image: redis:latest
+        name: redis-service
+        ports:
+        - containerPort: 6379
+      restartPolicy: Always

--- a/deployment/kubernetes/helm/cdn-transcode/templates/redis-service-service.yaml
+++ b/deployment/kubernetes/helm/cdn-transcode/templates/redis-service-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: redis-service
+  name: redis-service
+spec:
+  ports:
+  - name: "6379"
+    port: 6379
+    targetPort: 6379
+  selector:
+    app: redis-service

--- a/deployment/kubernetes/helm/cdn-transcode/templates/video-archive-pvc.yaml
+++ b/deployment/kubernetes/helm/cdn-transcode/templates/video-archive-pvc.yaml
@@ -1,0 +1,13 @@
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: video-archive
+spec:
+  accessModes:
+    - ReadOnlyMany
+  storageClassName: video-archive
+  resources:
+    requests:
+      storage: "{{ .Values.volume.video.archive.size }}"
+

--- a/deployment/kubernetes/helm/cdn-transcode/templates/video-dash-pvc.yaml
+++ b/deployment/kubernetes/helm/cdn-transcode/templates/video-dash-pvc.yaml
@@ -1,0 +1,13 @@
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: video-dash
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: video-dash
+  resources:
+    requests:
+      storage: "{{ .Values.volume.video.dash.size }}"
+

--- a/deployment/kubernetes/helm/cdn-transcode/templates/video-hls-pvc.yaml
+++ b/deployment/kubernetes/helm/cdn-transcode/templates/video-hls-pvc.yaml
@@ -1,0 +1,13 @@
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: video-hls
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: video-hls
+  resources:
+    requests:
+      storage: "{{ .Values.volume.video.hls.size }}"
+

--- a/deployment/kubernetes/helm/cdn-transcode/templates/vod-service-deployment.yaml
+++ b/deployment/kubernetes/helm/cdn-transcode/templates/vod-service-deployment.yaml
@@ -23,4 +23,22 @@ spec:
         image: ovc_software_transcode_service:latest
         imagePullPolicy: IfNotPresent
         name: vod-service
+        volumeMounts:
+          - mountPath: /var/www/archive
+            name: archive
+            readOnly: true
+          - mountPath: /var/www/dash
+            name: dash
+          - mountPath: /var/www/hls
+            name: hls
+      volumes:
+        - name: archive
+          persistentVolumeClaim:
+            claimName: video-archive
+        - name: dash
+          persistentVolumeClaim:
+            claimName: video-dash
+        - name: hls
+          persistentVolumeClaim:
+            claimName: video-hls
       restartPolicy: Always

--- a/deployment/kubernetes/helm/cdn-transcode/templates/vod-service-deployment.yaml
+++ b/deployment/kubernetes/helm/cdn-transcode/templates/vod-service-deployment.yaml
@@ -1,0 +1,26 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: vod-service
+  name: vod-service
+spec:
+  selector:
+    matchLabels:
+      app: vod-service
+  replicas: {{ .Values.vodTranscode.replicas }}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: vod-service
+    spec:
+      containers:
+      - args:
+        - bash
+        - -c
+        - /home/main.py
+        image: ovc_software_transcode_service:latest
+        imagePullPolicy: IfNotPresent
+        name: vod-service
+      restartPolicy: Always

--- a/deployment/kubernetes/helm/cdn-transcode/templates/zookeeper-service-deployment.yaml
+++ b/deployment/kubernetes/helm/cdn-transcode/templates/zookeeper-service-deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: zookeeper-service
+  name: zookeeper-service
+spec:
+  selector:
+    matchLabels:
+      app: zookeeper-service
+  replicas: 1
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: zookeeper-service
+    spec:
+      containers:
+      - env:
+        - name: ZOOKEEPER_CLIENT_PORT
+          value: "2181"
+        - name: ZOOKEEPER_HEAP_OPTS
+          value: -Xmx{{ .Values.zookeeper.heapSize }} -Xms{{ .Values.zookeeper.heapSize }}
+        - name: ZOOKEEPER_LOG4J_LOGGERS
+          value: zookeepr=ERROR
+        - name: ZOOKEEPER_LOG4J_ROOT_LOGLEVEL
+          value: ERROR
+        - name: ZOOKEEPER_MAX_CLIENT_CNXNS
+          value: "20000"
+        - name: ZOOKEEPER_SERVER_ID
+          value: "1"
+        - name: ZOOKEEPER_TICK_TIME
+          value: "2000"
+        image: zookeeper:latest
+        name: zookeeper-service
+        ports:
+        - containerPort: 2181
+      restartPolicy: Always

--- a/deployment/kubernetes/helm/cdn-transcode/templates/zookeeper-service-service.yaml
+++ b/deployment/kubernetes/helm/cdn-transcode/templates/zookeeper-service-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: zookeeper-service
+  name: zookeeper-service
+spec:
+  ports:
+  - name: "2181"
+    port: 2181
+    targetPort: 2181
+  selector:
+    app: zookeeper-service

--- a/deployment/kubernetes/helm/cdn-transcode/values.yaml.m4
+++ b/deployment/kubernetes/helm/cdn-transcode/values.yaml.m4
@@ -7,6 +7,27 @@ kafka:
 
 liveTranscode:
   replicas: defn(`NLIVES')
+  streams:
+    - name: "bbb_sunflower_1080p_30fps_normal.mp4"
+      transcode:
+        - protocol: dash
+          scale: "856:480"
+          bitrate: "8000000"
+          framerate: 25
+          gop: 100
+          maxbframes: 2
+          refsNum: 2
+          preset: veryfast
+          encoderType: libx264
+        - protocol: hls
+          scale: "856:480"
+          bitrate: "8000000"
+          framerate: 25
+          gop: 100
+          maxbframes: 2
+          refsNum: 2
+          preset: veryfast
+          encoderType: libsvt_hevc
 
 vodTranscode:
   replicas: defn(`NVODS')

--- a/deployment/kubernetes/helm/cdn-transcode/values.yaml.m4
+++ b/deployment/kubernetes/helm/cdn-transcode/values.yaml.m4
@@ -28,7 +28,7 @@ liveTranscode:
           gop: 100
           maxbframes: 2
           refsNum: 2
-          preset: veryfast
+          preset: 9
           encoderType: libsvt_hevc
 
 vodTranscode:

--- a/deployment/kubernetes/helm/cdn-transcode/values.yaml.m4
+++ b/deployment/kubernetes/helm/cdn-transcode/values.yaml.m4
@@ -17,3 +17,10 @@ cdn:
 volume:
   html: 
     size: defn(`HTML_VOLUME_SIZE')
+  video:
+    archive:
+      size: defn(`ARCHIVE_VOLUME_SIZE')
+    dash:
+      size: defn(`DASH_VOLUME_SIZE')
+    hls:
+      size: defn(`HLS_VOLUME_SIZE')

--- a/deployment/kubernetes/helm/cdn-transcode/values.yaml.m4
+++ b/deployment/kubernetes/helm/cdn-transcode/values.yaml.m4
@@ -8,7 +8,7 @@ kafka:
 liveTranscode:
   replicas: defn(`NLIVES')
   streams:
-    - name: "bbb_sunflower_1080p_30fps_normal.mp4"
+    - name: "/var/www/archive/bbb_sunflower_1080p_30fps_normal.mp4"
       transcode:
         - protocol: dash
           scale: "856:480"

--- a/deployment/kubernetes/helm/cdn-transcode/values.yaml.m4
+++ b/deployment/kubernetes/helm/cdn-transcode/values.yaml.m4
@@ -1,0 +1,19 @@
+
+zookeeper:
+  heapSize: 1024m
+
+kafka:
+  heapSize: 1024m
+
+liveTranscode:
+  replicas: defn(`NLIVES')
+
+vodTranscode:
+  replicas: defn(`NVODS')
+
+cdn:
+  hostIP: defn(`HOSTIP')
+
+volume:
+  html: 
+    size: defn(`HTML_VOLUME_SIZE')

--- a/deployment/kubernetes/helm/cdn-transcode/values.yaml.m4
+++ b/deployment/kubernetes/helm/cdn-transcode/values.yaml.m4
@@ -19,6 +19,8 @@ liveTranscode:
           refsNum: 2
           preset: veryfast
           encoderType: libx264
+    - name: "/var/www/archive/bbb_sunflower_1080p_30fps_normal.mp4"
+      transcode:
         - protocol: hls
           scale: "856:480"
           bitrate: "8000000"

--- a/deployment/kubernetes/helm/html-pv.yaml.m4
+++ b/deployment/kubernetes/helm/html-pv.yaml.m4
@@ -1,0 +1,31 @@
+
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: html
+provisioner: kubernetes.io/no-provisioner
+volumeBindingMode: WaitForFirstConsumer
+
+---
+
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: html
+spec:
+  capacity:
+    storage: defn(`HTML_VOLUME_SIZE')
+  accessModes:
+  - ReadOnlyMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: html
+  local:
+    path: defn(`HTML_VOLUME_PATH')
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          - "defn(`HTML_VOLUME_HOST')"

--- a/deployment/kubernetes/helm/mkvolume.sh
+++ b/deployment/kubernetes/helm/mkvolume.sh
@@ -1,0 +1,35 @@
+#!/bin/bash -e
+
+DIR=$(dirname $(readlink -f "$0"))
+
+echo "Making volumes..."
+HOSTS=$(kubectl get node -o 'custom-columns=NAME:.status.addresses[?(@.type=="Hostname")].address,IP:.status.addresses[?(@.type=="InternalIP")].address' | awk '!/NAME/{print $1":"$2}')
+awk -v DIR="$DIR" -v HOSTS="$HOSTS" '
+BEGIN{
+    split(HOSTS,tmp1," ");
+    for (i in tmp1) {
+        split(tmp1[i],tmp2,":");
+        host2ip[tmp2[1]]=tmp2[2];
+    }
+}
+/name:/ {
+    gsub("-","/",$2)
+    content="\""DIR"/../../../volume/"$2"\""
+}
+/path:/ {
+    path=$2
+}
+/- ".*"/ {
+    host=host2ip[substr($2,2,length($2)-2)];
+    paths[host][path]=1;
+    contents[host][path]=content
+}
+END {
+    for (host in paths) {
+        for (path in paths[host]) {
+            system("ssh "host" \"mkdir -p "path";find "path" -mindepth 1 -maxdepth 1 -exec rm -rf {} \\\\;\"");
+            system("scp -r "contents[host][path]"/* "host":"path);
+        }
+    }
+}
+' "$DIR"/*-pv.yaml

--- a/deployment/kubernetes/helm/start.sh
+++ b/deployment/kubernetes/helm/start.sh
@@ -1,0 +1,14 @@
+#!/bin/bash -e
+
+DIR=$(dirname $(readlink -f "$0"))
+
+function create_secret {
+    kubectl create secret generic self-signed-certificate "--from-file=${DIR}/../../certificate/self.crt" "--from-file=${DIR}/../../certificate/self.key"
+}
+
+# create secrets
+"$DIR/../../certificate/self-sign.sh"
+create_secret 2>/dev/null || (kubectl delete secret self-signed-certificate; create_secret)
+
+kubectl apply -f "$DIR"/*-pv.yaml
+helm install smtc "$DIR/cdn-transcode"

--- a/deployment/kubernetes/helm/start.sh
+++ b/deployment/kubernetes/helm/start.sh
@@ -13,4 +13,4 @@ create_secret 2>/dev/null || (kubectl delete secret self-signed-certificate; cre
 for yaml in $(find "$DIR" -maxdepth 1 -name "*-pv.yaml" -print); do
     kubectl apply -f "$yaml"
 done
-helm install smtc "$DIR/cdn-transcode"
+helm install cdn-transcode "$DIR/cdn-transcode"

--- a/deployment/kubernetes/helm/start.sh
+++ b/deployment/kubernetes/helm/start.sh
@@ -10,5 +10,7 @@ function create_secret {
 "$DIR/../../certificate/self-sign.sh"
 create_secret 2>/dev/null || (kubectl delete secret self-signed-certificate; create_secret)
 
-kubectl apply -f "$DIR"/*-pv.yaml
+for yaml in $(find "$DIR" -maxdepth 1 -name "*-pv.yaml" -print); do
+    kubectl apply -f "$yaml"
+done
 helm install smtc "$DIR/cdn-transcode"

--- a/deployment/kubernetes/helm/stop.sh
+++ b/deployment/kubernetes/helm/stop.sh
@@ -2,7 +2,7 @@
 
 DIR=$(dirname $(readlink -f "$0"))
 
-helm uninstall smtc
+helm uninstall cdn-transcode
 
 # delete pvs and scs
 for yaml in $(find "${DIR}" -maxdepth 1 -name "*-pv.yaml" -print); do

--- a/deployment/kubernetes/helm/stop.sh
+++ b/deployment/kubernetes/helm/stop.sh
@@ -6,7 +6,7 @@ helm uninstall cdn-transcode
 
 # delete pvs and scs
 for yaml in $(find "${DIR}" -maxdepth 1 -name "*-pv.yaml" -print); do
-    kubectl delete -f "$yaml" --ignore-not-found=true 2>/dev/null
+    kubectl delete --wait=false -f "$yaml" --ignore-not-found=true 2>/dev/null
 done
 
 kubectl delete secret self-signed-certificate 2> /dev/null || echo -n ""

--- a/deployment/kubernetes/helm/stop.sh
+++ b/deployment/kubernetes/helm/stop.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+DIR=$(dirname $(readlink -f "$0"))
+
+helm uninstall smtc
+
+# delete pvs and scs
+for yaml in $(find "${DIR}" -maxdepth 1 -name "*-pv.yaml" -print); do
+    kubectl delete -f "$yaml" --ignore-not-found=true 2>/dev/null
+done
+
+kubectl delete secret self-signed-certificate 2> /dev/null || echo -n ""

--- a/deployment/kubernetes/helm/video-archive-pv.yaml.m4
+++ b/deployment/kubernetes/helm/video-archive-pv.yaml.m4
@@ -1,0 +1,31 @@
+
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: video-archive
+provisioner: kubernetes.io/no-provisioner
+volumeBindingMode: WaitForFirstConsumer
+
+---
+
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: video-archive
+spec:
+  capacity:
+    storage: defn(`ARCHIVE_VOLUME_SIZE')
+  accessModes:
+  - ReadOnlyMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: video-archive
+  local:
+    path: defn(`ARCHIVE_VOLUME_PATH')
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          - "defn(`ARCHIVE_VOLUME_HOST')"

--- a/deployment/kubernetes/helm/video-dash-pv.yaml.m4
+++ b/deployment/kubernetes/helm/video-dash-pv.yaml.m4
@@ -1,0 +1,31 @@
+
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: video-dash
+provisioner: kubernetes.io/no-provisioner
+volumeBindingMode: WaitForFirstConsumer
+
+---
+
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: video-dash
+spec:
+  capacity:
+    storage: defn(`DASH_VOLUME_SIZE')
+  accessModes:
+  - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: video-dash
+  local:
+    path: defn(`DASH_VOLUME_PATH')
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          - "defn(`DASH_VOLUME_HOST')"

--- a/deployment/kubernetes/helm/video-hls-pv.yaml.m4
+++ b/deployment/kubernetes/helm/video-hls-pv.yaml.m4
@@ -1,0 +1,31 @@
+
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: video-hls
+provisioner: kubernetes.io/no-provisioner
+volumeBindingMode: WaitForFirstConsumer
+
+---
+
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: video-hls
+spec:
+  capacity:
+    storage: defn(`HLS_VOLUME_SIZE')
+  accessModes:
+  - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: video-hls
+  local:
+    path: defn(`HLS_VOLUME_PATH')
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          - "defn(`HLS_VOLUME_HOST')"

--- a/script/build.sh
+++ b/script/build.sh
@@ -12,9 +12,9 @@ for dep in .8 .7 .6 .5 .4 .3 .2 .1 ''; do
         if test -z "$dep"; then image="$IMAGE"; fi
 
         if grep -q 'AS build' "${DIR}/Dockerfile$dep"; then
-            docker build --network=host --file="${DIR}/Dockerfile$dep" --target build -t "$image:build" "$DIR" $(env | grep -E '_(proxy|REPO|VER)=' | sed 's/^/--build-arg /')
+            docker build --network=host --file="${DIR}/Dockerfile$dep" --target build -t "$image:build" "$DIR" $(env | grep -E '_(proxy|REPO|VER)=' | sed 's/^/--build-arg /') --build-arg UID=$(id -u) --build-arg GID=$(id -g)
         fi
 
-        docker build --network=host --file="${DIR}/Dockerfile$dep" -t "$image:latest" "$DIR" $(env | grep -E '_(proxy|REPO|VER)=' | sed 's/^/--build-arg /')
+        docker build --network=host --file="${DIR}/Dockerfile$dep" -t "$image:latest" "$DIR" $(env | grep -E '_(proxy|REPO|VER)=' | sed 's/^/--build-arg /') --build-arg UID=$(id -u) --build-arg GID=$(id -g)
     fi
 done


### PR DESCRIPTION
helm support is added per openness request under deployment/kubernetes/helm. See helm/cdn-transcode/README.md for details. It might make sense to move the current Kubernetes scripts a layer deeper to be under deployment/kubernetes/yaml.

